### PR TITLE
Update Discord invite link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -810,7 +810,7 @@
     "socials": {
       "x": "https://twitter.com/0xsequence",
       "github": "https://github.com/0xsequence",
-      "discord": "https://discord.gg/sequence"
+      "discord": "https://discord.com/invite/YnGKP7d3vS"
     }
   }
 }

--- a/sdk/overview.mdx
+++ b/sdk/overview.mdx
@@ -121,4 +121,4 @@ For mobile apps, explore the [React Native SDK](/sdk/mobile)
 
 ## Support
 
-Need help choosing or implementing an SDK? Join our [Discord community](https://discord.gg/sequence) for support and discussions. 
+Need help choosing or implementing an SDK? Join our [Discord community](https://discord.com/invite/YnGKP7d3vS) for support and discussions. 

--- a/sdk/typescript/guides/auth-address.mdx
+++ b/sdk/typescript/guides/auth-address.mdx
@@ -92,4 +92,4 @@ See the [Go Sequence SDK](https://github.com/0xsequence/go-sequence) on using Se
 If your server is written in a language other than Javascript/Typescript or Go, all you have to do is validate
 the signature with [EIP1271, the standard method for validating signed messages for a smart wallet](https://eips.ethereum.org/EIPS/eip-1271).
 
-As always, if you have any questions or require help, reach out to us on [Discord](https://discord.gg/sequence).
+As always, if you have any questions or require help, reach out to us on [Discord](https://discord.com/invite/YnGKP7d3vS).

--- a/solutions/overview.mdx
+++ b/solutions/overview.mdx
@@ -19,7 +19,7 @@ To learn more about how to leverage the powerful features that Sequence has to o
   <Card title="End to End Unity Game Guide" icon="unity" href="/guides/jelly-forest-unity-guide">
     Introducing Jelly Forest: a blockchain-enabled 2D runner game with social sign in, an in-game store, a backend transaction manager and more - all built in Unity using the Sequence platform.
   </Card>
-  <Card title="Join our Community" icon="discord" href="https://discord.com/invite/sequence">
+  <Card title="Join our Community" icon="discord" href="https://discord.com/invite/YnGKP7d3vS">
     Join our Discord for onboarding, support, share your project, and more!
   </Card>
 </CardGroup>

--- a/support/discord.mdx
+++ b/support/discord.mdx
@@ -1,4 +1,4 @@
 ---
 title: Discord
-url: "https://discord.gg/sequence"
+url: "https://discord.com/invite/YnGKP7d3vS"
 ---


### PR DESCRIPTION
Updates old Sequence Discord invite links to https://discord.com/invite/YnGKP7d3vS. Validation: searched fresh clones for old discord.gg/sequence, discord.com/invite/sequence, and legacy U69897fH invite forms; no remaining matches in patched repos.